### PR TITLE
Setup docker-compose to run lastest dev version easily

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,0 +1,11 @@
+version: '3'
+services: 
+  tezedge-node-explorer:
+    image: node:12.2.0 
+    ports: 
+      - "4200:4200"
+    volumes:
+      - ..:/app
+    working_dir: /app
+    command: bash -c "npm i && ./node_modules/.bin/ng serve --host 0.0.0.0"
+


### PR DESCRIPTION
This runs the currently checkout out code in docker.

I used it to set custom env variables (pointing it to our test node) to see what's going on there. 